### PR TITLE
Switched to using sphinx_rtd_theme

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,7 +47,7 @@ sphinxcontrib-websupport>=1.1.2
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.1.3,<2.4.0; python_version == '3.4'
 Pygments>=2.1.3; python_version >= '3.5'
-python-docs-theme>=2020.1
+sphinx-rtd-theme>=0.5.0
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',   # disabed, raises anexception
     'sphinx.ext.ifconfig',
-    'python_docs_theme',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -214,15 +214,17 @@ viewcode_import = True
 
 # The theme to use for HTML and HTML Help pages.
 # See https://www.sphinx-doc.org/en/stable/theming.html for built-in themes.
-html_theme = 'python_docs_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.
 # See https://www.sphinx-doc.org/en/stable/theming.html for the options
 # available for built-in themes.
+# For options of the 'sphinx_rtd_theme', see
+# https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html
 html_theme_options = {
-    'collapsiblesidebar': True,
-    'issues_url': 'https://github.com/pywbem/nocasedict/issues',
+    'style_external_links': False,
+    'collapse_navigation': False,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -162,7 +162,7 @@ GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2
 Pygments==2.1.3
-python-docs-theme==2020.1
+sphinx-rtd-theme==0.5.0
 
 # PyLint (no imports, invoked via pylint script) - does not support py3:
 pylint==1.6.4; python_version == '2.7'

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -13,4 +13,4 @@ sphinxcontrib-websupport>=1.1.2
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.1.3,<2.4.0; python_version == '3.4'
 Pygments>=2.1.3; python_version >= '3.5'
-python-docs-theme>=2020.1
+sphinx-rtd-theme>=0.5.0


### PR DESCRIPTION
See commit message.

An example of this theme can be seen here: https://sphinx-rtd-theme.readthedocs.io/en/latest/index.html
For looking at how this project looks like with it, you have to build the docs locally with `make builddoc`.