### PR TITLE
Excluded pytest 6.0.0 from test dependencies to fix not-callable issue

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,9 +12,10 @@
 # pytest
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
+# pytest 6.0.0 causes pylint to report "not-callable" issues
 pytest>=4.3.1,<5.0.0; python_version < '3.5'
-pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
-pytest>=4.4.0; python_version >= '3.7'
+pytest>=4.3.1,!=6.0.0; python_version >= '3.5' and python_version <= '3.6'
+pytest>=4.4.0,!=6.0.0; python_version >= '3.7'
 
 
 # Install test direct dependencies:


### PR DESCRIPTION
See commit message.
No review needed - priority.