### PR TITLE
Test: Fixed reversed test against built-in dict on py37

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Test: Fixed that the reversed test against the built-in dict was attempted
+  on Python 3.7, but the built-in dict became reversible only in Python 3.8.
+  (See issue #49)
+
 **Enhancements:**
 
 **Cleanup:**
@@ -33,4 +37,3 @@ nocasedict 0.5.0
 Released: 2020-07-29
 
 Initial release
-

--- a/tests/unittest/test_nocasedict.py
+++ b/tests/unittest/test_nocasedict.py
@@ -38,6 +38,10 @@ NocaseDict = dict if TEST_AGAINST_DICT else _NocaseDict
 TESTDICT_IS_ORDERED = \
     not TEST_AGAINST_DICT or sys.version_info[0:2] >= (3, 7)
 
+# Indicates the dict being tested is reversible
+TESTDICT_SUPPORTS_REVERSED = \
+    not TEST_AGAINST_DICT or sys.version_info[0:2] >= (3, 8)
+
 # Indicates the dict being tested supports lt/gt comparison (between dicts)
 TESTDICT_SUPPORTS_COMPARISON = \
     TEST_AGAINST_DICT and sys.version_info[0:2] == (2, 7)
@@ -1281,7 +1285,7 @@ TESTCASES_NOCASEDICT_REVERSED = [
             obj=NocaseDict(),
             exp_keys=[],
         ),
-        None, None, TESTDICT_IS_ORDERED
+        None, None, TESTDICT_SUPPORTS_REVERSED
     ),
     (
         "Dict with one item",
@@ -1289,7 +1293,7 @@ TESTCASES_NOCASEDICT_REVERSED = [
             obj=NocaseDict([('Dog', 'Cat')]),
             exp_keys=['Dog'],
         ),
-        None, None, TESTDICT_IS_ORDERED
+        None, None, TESTDICT_SUPPORTS_REVERSED
     ),
     (
         "Dict with two items",
@@ -1297,7 +1301,7 @@ TESTCASES_NOCASEDICT_REVERSED = [
             obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
             exp_keys=['Budgie', 'Dog'],
         ),
-        None, None, TESTDICT_IS_ORDERED
+        None, None, TESTDICT_SUPPORTS_REVERSED
     ),
 ]
 


### PR DESCRIPTION
See commit message.
Decided to give Karl some relief, so no review needed.