### PR TITLE
Docs: Fixed missing Python 2 only methods in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,11 +453,7 @@ html: develop_reqs_$(python_mn_version).done $(doc_build_dir)/html/docs/index.ht
 $(doc_build_dir)/html/docs/index.html: Makefile $(doc_dependent_files)
 	@echo "Makefile: Creating the documentation as HTML pages"
 	-$(call RM_FUNC,$@)
-ifeq ($(PLATFORM),Windows_native)
-	cmd /c "set DOCS_SHOW_ALL=1 & $(doc_cmd) -b html $(doc_opts) $(doc_build_dir)/html"
-else
-	DOCS_SHOW_ALL=1 $(doc_cmd) -b html $(doc_opts) $(doc_build_dir)/html
-endif
+	$(doc_cmd) -b html $(doc_opts) $(doc_build_dir)/html
 	@echo "Makefile: Done creating the documentation as HTML pages; top level file: $@"
 
 .PHONY: pdf

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,8 @@ Released: not yet
   pypy2. Removed these testcases, because the support for that feature in
   CPython 2.7 is not part of the Python language.
 
+* Docs: Fixed missing Python 2 only methods in RTD docs (See issue #52)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,6 +91,11 @@ if on_rtd:
 else:
     master_doc = 'docs/index'
 
+# This env var is evaluated in the nocasedict package and causes the methods
+# that are supposed to exist only in a particular Python version, not to be
+# removed, so they appear in the docs.
+os.environ['BUILDING_DOCS'] = '1'
+
 # General information about the project.
 project = u'nocasedict'
 #copyright = u''

--- a/nocasedict/_nocasedict.py
+++ b/nocasedict/_nocasedict.py
@@ -51,7 +51,10 @@ __all__ = ['NocaseDict']
 # pylint: disable=invalid-name
 ODict = dict if sys.version_info[0:2] >= (3, 7) else OrderedDict
 
-DOCS_SHOW_ALL = os.getenv('DOCS_SHOW_ALL')
+# This env var is set when building the docs. It causes the methods
+# that are supposed to exist only in a particular Python version, not to be
+# removed, so they appear in the docs.
+BUILDING_DOCS = os.environ.get('BUILDING_DOCS', False)
 
 # Used as default value for parameters to detect that they have not been
 # specified as an argument. Idea from CPython's datetime.timezone.
@@ -807,7 +810,7 @@ class NocaseDict(MutableMapping):
 # Remove methods that should only be present in a particular Python version
 # If the documentation is built, the methods are not removed in order to show
 # them in the documentation.
-if sys.version_info[0] != 2 and not DOCS_SHOW_ALL:
+if sys.version_info[0] != 2 and not BUILDING_DOCS:
     del NocaseDict.has_key
     del NocaseDict.iterkeys
     del NocaseDict.itervalues


### PR DESCRIPTION
See commit message.
No review needed.