### PR TITLE
Ignored Pylint issue 'consider-using-f-string' in new Pylint 2.11

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,9 @@ Released: not yet
 * Fixed a dependency error that caused importlib-metadata to be installed on
   Python 3.8, while it is included in the Python base.
 
+* Disabled new Pylint issue 'consider-using-f-string', since f-strings were
+  introduced only in Python 3.6.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pylintrc
+++ b/pylintrc
@@ -68,7 +68,7 @@ disable=I0011,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
-        bad-option-value, redundant-u-string-prefix,
+        bad-option-value, redundant-u-string-prefix, consider-using-f-string,
         R0801
 
 # TODO: R0801 was added due to https://github.com/PyCQA/pylint/issues/4118.


### PR DESCRIPTION
No review needed.