### PR TITLE
Fixed display of added setup.py commands (Pylint 2.13 issue)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,9 @@ Released: not yet
 
 * Fixed error when installing virtualenv in install test on Python 2.7.
 
+* Fixed that the added setup.py commands (test, leaktest, installtest) were not
+  displayed. They are now displayed at verbosity level 1 (using '-v').
+
 **Enhancements:**
 
 * Enhanced test matrix on GitHub Actions to always include Python 2.7 and

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,7 @@ import sys
 import os
 import io
 import re
-# setuptools needs to be imported before distutils in order to work.
 import setuptools
-from distutils import log  # pylint: disable=wrong-import-order
 
 
 def get_version(version_file):
@@ -116,12 +114,10 @@ class PytestCommand(setuptools.Command):
         args.extend(self.test_dirs)
 
         if self.dry_run:
-            self.announce("Dry-run: pytest {}".format(' '.join(args)),
-                          level=log.INFO)
+            self.announce("Dry-run: pytest {}".format(' '.join(args)), level=1)
             return 0
 
-        self.announce("pytest {}".format(' '.join(args)),
-                      level=log.INFO)
+        self.announce("pytest {}".format(' '.join(args)), level=1)
         rc = pytest.main(args)
         return rc
 


### PR DESCRIPTION
No review needed.