### PR TITLE
1.1: Resurrected support for byte string keys that was removed in 1.1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,12 +53,17 @@ the following exceptions (and the case-insensitivity of course):
 .. _dict class of Python 3.8: https://docs.python.org/3.8/library/stdtypes.html#dict
 
 The case-insensitivity is achieved by matching any key values as their
-casefolded values. By default, the casefolding is performed with
-`str.casefold()`_ on Python 3 and with `str.lower()`_ on Python 2.
+casefolded values. By default, the casefolding is performed as follows:
+
+* On Python 3, with `str.casefold()`_ for unicode string keys and with
+  `bytes.lower()`_ for byte string keys.
+
+* On Python 2, with `str.lower()`_.
+
 The default casefolding can be overridden with a user-defined casefold method.
 
-
 .. _str.casefold(): https://docs.python.org/3/library/stdtypes.html#str.casefold
+.. _bytes.lower(): https://docs.python.org/3/library/stdtypes.html#bytes.lower
 .. _str.lower(): https://docs.python.org/2/library/stdtypes.html#str.lower
 
 Functionality can be added using mixin classes:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Resurrected support for byte string keys that was removed in version 1.1.0.
+  (issue #139)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -42,8 +42,16 @@ the following exceptions (and the case-insensitivity of course):
 .. _dict class of Python 3.8: https://docs.python.org/3.8/library/stdtypes.html#dict
 
 The case-insensitivity is achieved by matching any key values as their
-casefolded values. By default, the casefolding is performed with
-:meth:`py:str.casefold` on Python 3 and with :meth:`py2:str.lower` on Python 2.
+casefolded values. By default, the casefolding is performed as follows:
+
+* On Python 3, with :meth:`py:str.casefold` for unicode string keys and with
+  :meth:`py:bytes.lower` for byte string keys.
+
+* On Python 2, with :meth:`py2:str.lower`.
+
+The :meth:`py:str.casefold` method implements the casefolding algorithm
+described in :term:`Default Case Folding in The Unicode Standard`.
+
 The default casefolding can be overridden with a user-defined casefold method.
 
 Functionality can be added using mixin classes:
@@ -64,23 +72,15 @@ not well maintained, or did not support the Python versions we needed.
 Overriding the default casefold method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The case-insensitive behavior of the :class:`~nocasedict.NocaseDict` class
-is implemented in its :meth:`~nocasedict.NocaseDict.__casefold__` method. That
-method returns the casefolded key that is used for the case-insensitive lookup
-of dictionary items.
-
-The default implementation of the :meth:`~nocasedict.NocaseDict.__casefold__`
-method calls :meth:`py:str.casefold` on Python 3 and :meth:`py2:str.lower` on
-Python 2. The :meth:`py:str.casefold` method implements the casefolding
-algorithm described in :term:`Default Case Folding in The Unicode Standard`.
-
-If it is necessary to change the case-insensitive behavior of the
+If it is necessary to change the default case-insensitive behavior of the
 :class:`~nocasedict.NocaseDict` class, that can be done by overriding its
 :meth:`~nocasedict.NocaseDict.__casefold__` method.
 
+That method returns the casefolded key that is used for the case-insensitive
+lookup of dictionary items.
+
 The following Python 3 example shows how your own casefold method would
 be used, that normalizes the key in addition to casefolding it:
-
 
 .. code-block:: python
 

--- a/nocasedict/_nocasedict.py
+++ b/nocasedict/_nocasedict.py
@@ -258,7 +258,6 @@ class NocaseDict(MutableMapping):
             dict6 = NocaseDict(dict1, BETA=3)
 
         Raises:
-          AttributeError: The key does not have the casefold method.
           TypeError: Expected at most 1 positional argument, got {n}.
           ValueError: Cannot unpack positional argument item #{i}.
         """
@@ -286,27 +285,28 @@ class NocaseDict(MutableMapping):
         It returns a case-insensitive form of the input key by calling a
         "casefold method" on the key. The input key will not be `None`.
 
-        The casefold method called by this method is :meth:`py:str.casefold`
-        on Python 3 and :meth:`py2:str.lower` on Python 2.
+        The casefold method called by this method is :meth:`py2:str.lower` on
+        Python 2, and on Python 3 it is :meth:`py:str.casefold`, falling back
+        to :meth:`py:bytes.lower` if it does not exist.
 
         This method can be overridden by users in order to change the
         case-insensitive behavior of the class.
         See :ref:`Overriding the default casefold method` for details.
 
         Parameters:
-            key (str or unicode): Input key, as a unicode string or in
-              Python 2 also as a byte string. Will not be `None`.
+            key (str or unicode): Input key. Will not be `None`.
 
         Returns:
-            str or unicode: Case-insensitive form of the input key, as a
-            unicode string or in Python 2 also as a byte string.
+            str or unicode: Case-insensitive form of the input key.
 
         Raises:
           AttributeError: The key does not have the casefold method.
         """
-        if six.PY2:
+        try:
+            return key.casefold()
+        except AttributeError:
+            # Either Python 2, or Python 3 and a byte string key
             return key.lower()
-        return key.casefold()
 
     # Basic accessor and setter methods
 

--- a/tests/unittest/test_nocasedict.py
+++ b/tests/unittest/test_nocasedict.py
@@ -379,19 +379,37 @@ TESTCASES_NOCASEDICT_GETITEM = [
         KeyError if TEST_AGAINST_DICT else AttributeError, None, True
     ),
     (
-        "Empty dict, with empty string key (not found)",
+        "Empty dict, with empty unicode string key (not found)",
         dict(
             obj=NocaseDict(),
-            key='',
+            key=u'',
             exp_value=None,
         ),
         KeyError, None, True
     ),
     (
-        "Empty dict, with non-empty key (not found)",
+        "Empty dict, with empty byte string key (not found)",
         dict(
             obj=NocaseDict(),
-            key='Dog',
+            key=b'',
+            exp_value=None,
+        ),
+        KeyError, None, True
+    ),
+    (
+        "Empty dict, with non-empty unicode string key (not found)",
+        dict(
+            obj=NocaseDict(),
+            key=u'Dog',
+            exp_value=None,
+        ),
+        KeyError, None, True
+    ),
+    (
+        "Empty dict, with non-empty byte string key (not found)",
+        dict(
+            obj=NocaseDict(),
+            key=b'Dog',
             exp_value=None,
         ),
         KeyError, None, True
@@ -401,65 +419,145 @@ TESTCASES_NOCASEDICT_GETITEM = [
     (
         "Non-empty dict, with None key (not found)",
         dict(
-            obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
             key=None,
             exp_value=None,
         ),
         KeyError, None, True
     ),
     (
-        "Non-empty dict, with empty string key (not found)",
+        "Non-empty dict, with empty unicode string key (not found)",
         dict(
-            obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
-            key='',
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=u'',
             exp_value=None,
         ),
         KeyError, None, True
     ),
     (
-        "Non-empty dict, with non-empty non-existing key (not found)",
+        "Non-empty dict, with empty byte string key (not found)",
         dict(
-            obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
-            key='invalid',
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=b'',
             exp_value=None,
         ),
         KeyError, None, True
     ),
     (
-        "Non-empty dict, with existing key in original case",
+        "Non-empty dict, with non-empty non-existing unicode string key "
+        "(not found)",
         dict(
-            obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
-            key='Dog',
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=u'invalid',
+            exp_value=None,
+        ),
+        KeyError, None, True
+    ),
+    (
+        "Non-empty dict, with non-empty non-existing byte string key "
+        "(not found)",
+        dict(
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=b'invalid',
+            exp_value=None,
+        ),
+        KeyError, None, True
+    ),
+    (
+        "Non-empty dict, with existing unicode string key in original case",
+        dict(
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=u'Dog',
             exp_value='Cat',
         ),
         None, None, True
     ),
     (
-        "Non-empty dict, with existing key in non-original upper case",
+        "Non-empty dict, with existing byte string key in original case",
         dict(
-            obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
-            key='DOG',
+            obj=NocaseDict([(b'Dog', 'Cat'), (b'Budgie', 'Fish')]),
+            key=b'Dog',
+            exp_value='Cat',
+        ),
+        None, None, True
+    ),
+    (
+        "Non-empty dict, with existing unicode string key in non-original "
+        "upper case",
+        dict(
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=u'DOG',
             exp_value='Cat',
         ),
         KeyError if TEST_AGAINST_DICT else None, None, True
     ),
     (
-        "Non-empty dict, with existing key in non-original lower case",
+        "Non-empty dict, with existing byte string key in non-original "
+        "upper case",
         dict(
-            obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
-            key='dog',
+            obj=NocaseDict([(b'Dog', 'Cat'), (b'Budgie', 'Fish')]),
+            key=b'DOG',
             exp_value='Cat',
         ),
         KeyError if TEST_AGAINST_DICT else None, None, True
     ),
     (
-        "Non-empty dict, with existing key in non-original mixed case",
+        "Non-empty dict, with existing unicode string key in non-original "
+        "lower case",
         dict(
-            obj=NocaseDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
-            key='doG',
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=u'dog',
             exp_value='Cat',
         ),
         KeyError if TEST_AGAINST_DICT else None, None, True
+    ),
+    (
+        "Non-empty dict, with existing byte string key in non-original "
+        "lower case",
+        dict(
+            obj=NocaseDict([(b'Dog', 'Cat'), (b'Budgie', 'Fish')]),
+            key=b'dog',
+            exp_value='Cat',
+        ),
+        KeyError if TEST_AGAINST_DICT else None, None, True
+    ),
+    (
+        "Non-empty dict, with existing unicode string key in non-original "
+        "mixed case",
+        dict(
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=u'doG',
+            exp_value='Cat',
+        ),
+        KeyError if TEST_AGAINST_DICT else None, None, True
+    ),
+    (
+        "Non-empty dict, with existing byte string key in non-original "
+        "mixed case",
+        dict(
+            obj=NocaseDict([(b'Dog', 'Cat'), (b'Budgie', 'Fish')]),
+            key=b'doG',
+            exp_value='Cat',
+        ),
+        KeyError if TEST_AGAINST_DICT else None, None, True
+    ),
+    (
+        "Non-empty unicode string dict, with same byte string key",
+        dict(
+            obj=NocaseDict([(u'Dog', 'Cat'), (u'Budgie', 'Fish')]),
+            key=b'Dog',
+            exp_value='Cat',
+        ),
+        None if PY2 else KeyError, None, True
+    ),
+    (
+        "Non-empty byte string dict, with same unicode string key",
+        dict(
+            obj=NocaseDict([(b'Dog', 'Cat'), (b'Budgie', 'Fish')]),
+            key=u'Dog',
+            exp_value='Cat',
+        ),
+        None if PY2 else KeyError, None, True
     ),
 ]
 


### PR DESCRIPTION
Rolls back PR #144 into 1.1.1.